### PR TITLE
add repl command to sage

### DIFF
--- a/bin/sage
+++ b/bin/sage
@@ -26,6 +26,11 @@ fi
 COMMAND="$1"
 shift
 
+if [[ "$COMMAND" == "repl" ]]; then
+  exec "$TSX_EXEC"
+  exit 0
+fi
+
 if [[ "$COMMAND" != "run" ]]; then
   echo "Command not supported: $COMMAND" >&2
   exit 1


### PR DESCRIPTION
By submitting this PR, I am indicating to the PhET maintainers that I have read and understood
the [contributing guidelines](../CONTRIBUTING.md) and that this PR follows those guidelines to the best of my knowledge.
I also understand that my PR can't be merged until I have singed the [contributor license agreement](../CLA.md).

<hr/>

This PR adds a new command to sage to open a typescript compatible node command prompt. Used like this:
```
$ sage repl                                   
Welcome to Node.js v24.11.1.
Type ".help" for more information.
> const {IS_TEST} = await import('./util/util.ts')
undefined
> console.log(IS_TEST)
false
undefined
```
